### PR TITLE
AMRNAV-6169 Extend use of composition: ros2 control

### DIFF
--- a/controller_interface/src/controller_interface_base.cpp
+++ b/controller_interface/src/controller_interface_base.cpp
@@ -29,7 +29,9 @@ return_type ControllerInterfaceBase::init(
   const rclcpp::NodeOptions & node_options)
 {
   node_ = std::make_shared<rclcpp_lifecycle::LifecycleNode>(
-    controller_name, namespace_, node_options, false);  // disable LifecycleNode service interfaces
+    controller_name, namespace_, rclcpp::NodeOptions().enable_logger_service(true).arguments({
+    "--ros-args",
+    "--remap", ("__node:=" + controller_name).c_str()}), false);  // disable LifecycleNode service interfaces
 
   try
   {

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -15,6 +15,8 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   rclcpp
   realtime_tools
   std_msgs
+  rclcpp_components
+  rclcpp_lifecycle
 )
 
 find_package(ament_cmake REQUIRED)
@@ -43,6 +45,8 @@ add_executable(ros2_control_node src/ros2_control_node.cpp)
 target_link_libraries(ros2_control_node PRIVATE
   controller_manager
 )
+
+rclcpp_components_register_nodes(controller_manager "controller_manager::ControllerManager")
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
@@ -222,5 +226,6 @@ ament_python_install_package(controller_manager
   SCRIPTS_DESTINATION lib/controller_manager
 )
 ament_export_targets(export_controller_manager HAS_LIBRARY_TARGET)
+ament_export_libraries(controller_manager) 
 ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 ament_package()

--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -329,6 +329,7 @@ protected:
   // Per controller update rate support
   unsigned int update_loop_counter_ = 0;
   unsigned int update_rate_ = 100;
+  bool enforce_rt_fifo_ = false;
   std::vector<std::vector<std::string>> chained_controllers_configuration_;
 
   std::unique_ptr<hardware_interface::ResourceManager> resource_manager_;

--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -54,6 +54,7 @@
 #include "rclcpp/parameter.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/string.hpp"
+#include "realtime_tools/thread_priority.hpp"
 
 namespace controller_manager
 {
@@ -86,7 +87,8 @@ public:
   explicit ControllerManager(rclcpp::NodeOptions options);
 
   CONTROLLER_MANAGER_PUBLIC
-  virtual ~ControllerManager() = default;
+  ~ControllerManager();
+  
 
   CONTROLLER_MANAGER_PUBLIC
   void robot_description_callback(const std_msgs::msg::String & msg);
@@ -175,6 +177,9 @@ public:
   CONTROLLER_MANAGER_PUBLIC
   controller_interface::return_type update(
     const rclcpp::Time & time, const rclcpp::Duration & period);
+
+  CONTROLLER_MANAGER_PUBLIC
+  void update_loop();
 
   /// Write values from command interfaces.
   /**
@@ -422,6 +427,8 @@ private:
 
   std::shared_ptr<rclcpp::Executor> executor_;
   std::thread spin_executor_thread;
+  rclcpp::TimerBase::SharedPtr init_timer_;
+  std::thread cm_thread_;
 
   std::shared_ptr<pluginlib::ClassLoader<controller_interface::ControllerInterface>> loader_;
   std::shared_ptr<pluginlib::ClassLoader<controller_interface::ChainableControllerInterface>>

--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -83,6 +83,12 @@ public:
     const std::string & namespace_ = "",
     const rclcpp::NodeOptions & options = get_cm_node_options());
   
+
+  /**
+   * Contstuctor for launching ControllerManager as a component.
+   * Creates an executor for controllers and spins it.
+   * Also runs the update loop in a thread.
+  */
   CONTROLLER_MANAGER_PUBLIC
   explicit ControllerManager(rclcpp::NodeOptions options);
 
@@ -426,7 +432,7 @@ private:
   diagnostic_updater::Updater diagnostics_updater_;
 
   std::shared_ptr<rclcpp::Executor> executor_;
-  std::thread spin_executor_thread;
+  std::thread spin_executor_thread_;
   rclcpp::TimerBase::SharedPtr init_timer_;
   std::thread cm_thread_;
 

--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -21,6 +21,7 @@
 #include <tuple>
 #include <unordered_map>
 #include <utility>
+#include <thread>
 #include <vector>
 
 #include "controller_interface/chainable_controller_interface.hpp"
@@ -80,6 +81,9 @@ public:
     const std::string & manager_node_name = "controller_manager",
     const std::string & namespace_ = "",
     const rclcpp::NodeOptions & options = get_cm_node_options());
+  
+  CONTROLLER_MANAGER_PUBLIC
+  explicit ControllerManager(rclcpp::NodeOptions options);
 
   CONTROLLER_MANAGER_PUBLIC
   virtual ~ControllerManager() = default;
@@ -417,6 +421,7 @@ private:
   diagnostic_updater::Updater diagnostics_updater_;
 
   std::shared_ptr<rclcpp::Executor> executor_;
+  std::thread spin_executor_thread;
 
   std::shared_ptr<pluginlib::ClassLoader<controller_interface::ControllerInterface>> loader_;
   std::shared_ptr<pluginlib::ClassLoader<controller_interface::ChainableControllerInterface>>

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -27,6 +27,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/state.hpp"
 
+using namespace std::chrono_literals;
 namespace  // utility
 {
 static constexpr const char * kControllerInterfaceNamespace = "controller_interface";
@@ -263,6 +264,7 @@ ControllerManager::ControllerManager(rclcpp::NodeOptions options)
   {
     RCLCPP_WARN(get_logger(), "'update_rate' parameter not set, using default value.");
   }
+  auto update_period = std::chrono::duration<double>(1.0 / update_rate_);
 
   std::string robot_description = "";
   // TODO(destogl): remove support at the end of 2023
@@ -288,6 +290,13 @@ ControllerManager::ControllerManager(rclcpp::NodeOptions options)
   spin_executor_thread = std::thread([this]() {
     executor_->spin();
   });
+  //timer_ = this->create_timer(std::chrono::milliseconds(1000), std::bind(&ControllerManager::update_loop, this));
+  init_timer_ = this->create_wall_timer(
+    1s,
+    [this]() -> void {
+      init_timer_->cancel();
+      update_loop();
+    });
 };
 
 ControllerManager::ControllerManager(
@@ -345,6 +354,7 @@ ControllerManager::ControllerManager(
     std::make_shared<pluginlib::ClassLoader<controller_interface::ChainableControllerInterface>>(
       kControllerInterfaceNamespace, kChainableControllerInterfaceClassName))
 {
+  RCLCPP_INFO(get_logger(), "THIS CONSTRUCTOR");
   if (!get_parameter("update_rate", update_rate_))
   {
     RCLCPP_WARN(get_logger(), "'update_rate' parameter not set, using default value.");
@@ -352,13 +362,18 @@ ControllerManager::ControllerManager(
 
   if (resource_manager_->is_urdf_already_loaded())
   {
+    RCLCPP_INFO(get_logger(), "URDF ALREADY LOADED");
     init_services();
+  }
+  else {
+    RCLCPP_INFO(get_logger(), "URDF NOT LOADED");
   }
   subscribe_to_robot_description_topic();
 
   diagnostics_updater_.setHardwareID("ros2_control");
   diagnostics_updater_.add(
     "Controllers Activity", this, &ControllerManager::controller_activity_diagnostic_callback);
+  RCLCPP_INFO(get_logger(), "THIS CONSTRUCTOR EXIT");
 }
 
 void ControllerManager::subscribe_to_robot_description_topic()
@@ -506,6 +521,54 @@ void ControllerManager::init_resource_manager(const std::string & robot_descript
       resource_manager_->set_component_state(component, active_state);
     }
   }
+}
+
+
+void ControllerManager::update_loop(){
+
+  RCLCPP_WARN(this->get_logger(), "On update loop");
+
+  cm_thread_ = std::thread(
+    [this]()
+    {
+      if (realtime_tools::has_realtime_kernel())
+      {
+        if (!realtime_tools::configure_sched_fifo(50))
+        {
+          RCLCPP_WARN(this->get_logger(), "Could not enable FIFO RT scheduling policy");
+        }
+      }
+      else
+      {
+        RCLCPP_INFO(this->get_logger(), "RT kernel is recommended for better performance");
+      }
+
+      // for calculating sleep time
+      auto const period = std::chrono::nanoseconds(1'000'000'000 / this->get_update_rate());
+      auto const cm_now = std::chrono::nanoseconds(this->now().nanoseconds());
+      std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>
+        next_iteration_time{cm_now};
+
+      // for calculating the measured period of the loop
+      rclcpp::Time previous_time = this->now();
+
+      while (rclcpp::ok())
+      {
+        // calculate measured period
+        auto const current_time = this->now();
+        auto const measured_period = current_time - previous_time;
+        previous_time = current_time;
+
+        // execute update loop
+        this->read(this->now(), measured_period);
+        this->update(this->now(), measured_period);
+        this->write(this->now(), measured_period);
+
+        // wait until we hit the end of the period
+        next_iteration_time += period;
+        std::this_thread::sleep_until(next_iteration_time);
+      }
+    });
 }
 
 void ControllerManager::init_services()
@@ -956,6 +1019,7 @@ controller_interface::return_type ControllerManager::switch_controller(
 
     return controller_interface::return_type::OK;
   };
+  RCLCPP_DEBUG(get_logger(), "Going further");
 
   // list all controllers to deactivate (check if all controllers exist)
   auto ret = list_controllers(deactivate_controllers, deactivate_request_, "deactivate");
@@ -1006,6 +1070,8 @@ controller_interface::return_type ControllerManager::switch_controller(
       ret = check_following_controllers_for_activate(controllers, strictness, controller_it);
     }
 
+    RCLCPP_DEBUG(get_logger(), "Going even further");
+
     if (ret != controller_interface::return_type::OK)
     {
       RCLCPP_WARN(
@@ -1033,6 +1099,8 @@ controller_interface::return_type ControllerManager::switch_controller(
       }
     }
   }
+
+  RCLCPP_DEBUG(get_logger(), "Going even further 2");
 
   // check if controllers should be deactivated if used in chained mode
   for (auto ctrl_it = deactivate_request_.begin(); ctrl_it != deactivate_request_.end(); ++ctrl_it)
@@ -1193,6 +1261,8 @@ controller_interface::return_type ControllerManager::switch_controller(
         command_interface_names.end());
     };
 
+    RCLCPP_DEBUG(get_logger(), "Going even further 3");
+
     if (in_activate_list)
     {
       extract_interfaces_for_controller(controller, activate_command_interface_request_);
@@ -1209,6 +1279,7 @@ controller_interface::return_type ControllerManager::switch_controller(
     // to a hardware when error in hardware happens
     if (in_activate_list)
     {
+      RCLCPP_DEBUG(get_logger(), "Going even further 4");
       std::vector<std::string> interface_names = {};
 
       auto command_interface_config = controller.c->command_interface_configuration();
@@ -1252,6 +1323,7 @@ controller_interface::return_type ControllerManager::switch_controller(
   if (
     !activate_command_interface_request_.empty() || !deactivate_command_interface_request_.empty())
   {
+    RCLCPP_DEBUG(get_logger(), "Prepare command mode switch");
     if (!resource_manager_->prepare_command_mode_switch(
           activate_command_interface_request_, deactivate_command_interface_request_))
     {
@@ -1280,6 +1352,7 @@ controller_interface::return_type ControllerManager::switch_controller(
     }
     std::this_thread::sleep_for(std::chrono::microseconds(100));
   }
+  RCLCPP_DEBUG(get_logger(), "loop exit");
 
   // copy the controllers spec from the used to the unused list
   std::vector<ControllerSpec> & to = rt_controllers_wrapper_.get_unused_list(guard);
@@ -1378,10 +1451,17 @@ controller_interface::ControllerInterfaceBaseSharedPtr ControllerManager::add_co
 
   return to.back().c;
 }
+ControllerManager::~ControllerManager()
+{
+  RCLCPP_DEBUG(get_logger(), "Destructing controller manager");
+  cm_thread_.join();
+  RCLCPP_DEBUG(get_logger(), "Done destructing controller manager");
+}
 
 void ControllerManager::manage_switch()
 {
   // Ask hardware interfaces to change mode
+  RCLCPP_ERROR(get_logger(), "ON MANAGE SWITCH.");
   if (!resource_manager_->perform_command_mode_switch(
         activate_command_interface_request_, deactivate_command_interface_request_))
   {
@@ -1504,6 +1584,7 @@ void ControllerManager::activate_controllers(
   const std::vector<ControllerSpec> & rt_controller_list,
   const std::vector<std::string> controllers_to_activate)
 {
+  RCLCPP_DEBUG(get_logger(),"On activate controllers");
   for (const auto & request : controllers_to_activate)
   {
     auto found_it = std::find_if(
@@ -1567,6 +1648,7 @@ void ControllerManager::activate_controllers(
     {
       continue;
     }
+    RCLCPP_DEBUG(get_logger(),"On activate controllers 2");
 
     // assign state interfaces to the controller
     auto state_interface_config = controller->state_interface_configuration();
@@ -1583,6 +1665,7 @@ void ControllerManager::activate_controllers(
     }
     std::vector<hardware_interface::LoanedStateInterface> state_loans;
     state_loans.reserve(state_interface_names.size());
+    RCLCPP_DEBUG(get_logger(),"On activate controllers 3");
     for (const auto & state_interface : state_interface_names)
     {
       try
@@ -1601,6 +1684,7 @@ void ControllerManager::activate_controllers(
     {
       continue;
     }
+    RCLCPP_DEBUG(get_logger(),"On activate controllers 4");
     controller->assign_interfaces(std::move(command_loans), std::move(state_loans));
 
     const auto new_state = controller->get_node()->activate();
@@ -1621,6 +1705,7 @@ void ControllerManager::activate_controllers(
   }
   // All controllers activated, switching done
   switch_params_.do_switch = false;
+  RCLCPP_DEBUG(get_logger(),"On activate controllers 5");
 }
 
 void ControllerManager::activate_controllers_asap(

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -264,6 +264,10 @@ ControllerManager::ControllerManager(rclcpp::NodeOptions options)
   {
     RCLCPP_WARN(get_logger(), "'update_rate' parameter not set, using default value.");
   }
+  if (!get_parameter("enforce_rt_fifo", enforce_rt_fifo_))
+  {
+    RCLCPP_INFO(get_logger(), "'enforce_rt_fifo' parameter not set, using default value.");
+  }
   auto update_period = std::chrono::duration<double>(1.0 / update_rate_);
 
   std::string robot_description = "";
@@ -517,7 +521,7 @@ void ControllerManager::update_loop(){
   cm_thread_ = std::thread(
     [this]()
     {
-      if (realtime_tools::has_realtime_kernel())
+      if (realtime_tools::has_realtime_kernel() || enforce_rt_fifo_)
       {
         if (!realtime_tools::configure_sched_fifo(50))
         {

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -295,7 +295,7 @@ ControllerManager::ControllerManager(rclcpp::NodeOptions options)
   });
   init_services();
   init_timer_ = this->create_wall_timer(
-    1s,
+    50ms,
     [this]() -> void {
       init_timer_->cancel();
       update_loop();

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -332,12 +332,12 @@ ControllerManager::ControllerManager(
       "[Deprecated] Passing the robot description parameter directly to the control_manager node "
       "is deprecated. Use '~/robot_description' topic from 'robot_state_publisher' instead.");
     init_resource_manager(robot_description);
-    init_services();
   }
 
   diagnostics_updater_.setHardwareID("ros2_control");
   diagnostics_updater_.add(
     "Controllers Activity", this, &ControllerManager::controller_activity_diagnostic_callback);
+  init_services();
 }
 
 ControllerManager::ControllerManager(
@@ -360,20 +360,12 @@ ControllerManager::ControllerManager(
     RCLCPP_WARN(get_logger(), "'update_rate' parameter not set, using default value.");
   }
 
-  if (resource_manager_->is_urdf_already_loaded())
-  {
-    RCLCPP_INFO(get_logger(), "URDF ALREADY LOADED");
-    init_services();
-  }
-  else {
-    RCLCPP_INFO(get_logger(), "URDF NOT LOADED");
-  }
   subscribe_to_robot_description_topic();
 
   diagnostics_updater_.setHardwareID("ros2_control");
   diagnostics_updater_.add(
     "Controllers Activity", this, &ControllerManager::controller_activity_diagnostic_callback);
-  RCLCPP_INFO(get_logger(), "THIS CONSTRUCTOR EXIT");
+  init_services();
 }
 
 void ControllerManager::subscribe_to_robot_description_topic()
@@ -407,7 +399,6 @@ void ControllerManager::robot_description_callback(const std_msgs::msg::String &
       return;
     }
     init_resource_manager(robot_description.data.c_str());
-    init_services();
   }
   catch (std::runtime_error & e)
   {

--- a/controller_manager/test/test_hardware_management_srvs.cpp
+++ b/controller_manager/test/test_hardware_management_srvs.cpp
@@ -84,9 +84,7 @@ public:
         "Unable to initialize resource manager, no robot description found.");
     }
 
-    auto msg = std_msgs::msg::String();
-    msg.data = robot_description_;
-    cm_->robot_description_callback(msg);
+    cm_->init_resource_manager(robot_description);
 
     SetUpSrvsCMExecutor();
   }
@@ -385,9 +383,7 @@ public:
         "Unable to initialize resource manager, no robot description found.");
     }
 
-    auto msg = std_msgs::msg::String();
-    msg.data = robot_description_;
-    cm_->robot_description_callback(msg);
+    cm_->init_resource_manager(robot_description);
 
     SetUpSrvsCMExecutor();
   }
@@ -444,9 +440,7 @@ public:
         "Unable to initialize resource manager, no robot description found.");
     }
 
-    auto msg = std_msgs::msg::String();
-    msg.data = robot_description_;
-    cm_->robot_description_callback(msg);
+    cm_->init_resource_manager(robot_description);
 
     SetUpSrvsCMExecutor();
   }

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -41,6 +41,7 @@ target_compile_definitions(hardware_interface PRIVATE "HARDWARE_INTERFACE_BUILDI
 
 add_library(mock_components SHARED
   src/mock_components/generic_system.cpp
+  src/lexical_casts.cpp
 )
 target_compile_features(mock_components PUBLIC cxx_std_17)
 target_include_directories(mock_components PUBLIC


### PR DESCRIPTION
Ticket: https://lvserv01.logivations.com/browse/AMRNAV-6169
Documentation: https://coda.io/d/Autonomous-Mobile-Robot_da82dg_s4hc/Composable-Nodes_suvus?searchClick=0d961e16-bddd-4703-ac21-3d9465d6bcfb_a82dg_s4hc#_luraL

Changes in this PR:
* Add support for running controller_manager as a composed node
* Revert https://github.com/ros-controls/ros2_control/pull/1271 due to https://github.com/ros-controls/ros2_control/issues/1299
See the PR comments for the rest of the changes

